### PR TITLE
refactor gRPC client usage to replace deprecated method

### DIFF
--- a/trainings/clone.go
+++ b/trainings/clone.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (h *Handlers) Clone(ctx context.Context, executionID string, directory string) error {
-	resp, err := h.newGrpcClient(ctx).GetSolutionFiles(ctx, &genproto.GetSolutionFilesRequest{
+	resp, err := h.newGrpcClient().GetSolutionFiles(ctx, &genproto.GetSolutionFilesRequest{
 		ExecutionId: executionID,
 	})
 	if err != nil {

--- a/trainings/configure.go
+++ b/trainings/configure.go
@@ -15,7 +15,7 @@ func (h *Handlers) ConfigureGlobally(ctx context.Context, token, serverAddr, reg
 		}
 	}
 
-	resp, err := h.newGrpcClientWithAddr(ctx, serverAddr, region, insecure).Init(
+	resp, err := h.newGrpcClientWithAddr(serverAddr, region, insecure).Init(
 		ctxWithRequestHeader(ctx, h.cliMetadata),
 		&genproto.InitRequest{
 			Token: token,

--- a/trainings/handlers.go
+++ b/trainings/handlers.go
@@ -1,7 +1,6 @@
 package trainings
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -47,13 +46,13 @@ func NewHandlers(cliVersion CliMetadata) *Handlers {
 	}
 }
 
-func (h *Handlers) newGrpcClient(ctx context.Context) genproto.TrainingsClient {
+func (h *Handlers) newGrpcClient() genproto.TrainingsClient {
 	globalConfig := h.config.GlobalConfig()
 
-	return h.newGrpcClientWithAddr(ctx, globalConfig.ServerAddr, globalConfig.Region, globalConfig.Insecure)
+	return h.newGrpcClientWithAddr(globalConfig.ServerAddr, globalConfig.Region, globalConfig.Insecure)
 }
 
-func (h *Handlers) newGrpcClientWithAddr(ctx context.Context, addr string, region string, insecure bool) genproto.TrainingsClient {
+func (h *Handlers) newGrpcClientWithAddr(addr string, region string, insecure bool) genproto.TrainingsClient {
 	if addr == "" {
 		addr = internal.DefaultTrainingsServer
 	}
@@ -82,7 +81,7 @@ func (h *Handlers) newGrpcClientWithAddr(ctx context.Context, addr string, regio
 			opts = append(opts, grpc.WithTransportCredentials(creds))
 		}
 
-		conn, err := grpc.DialContext(ctx, addr, opts...)
+		conn, err := grpc.NewClient(addr, opts...)
 
 		if err != nil {
 			panic(err)

--- a/trainings/init.go
+++ b/trainings/init.go
@@ -119,13 +119,13 @@ func (h *Handlers) startTraining(
 			return "", errors.Wrap(err, "can't create training root dir")
 		}
 
-		err = createGoWorkspace(trainingRootDir, trainingName)
+		err = createGoWorkspace(trainingRootDir)
 		if err != nil {
 			logrus.WithError(err).Warn("Could not create go workspace")
 		}
 	}
 
-	_, err = h.newGrpcClient(ctx).StartTraining(
+	_, err = h.newGrpcClient().StartTraining(
 		ctxWithRequestHeader(ctx, h.cliMetadata),
 		&genproto.StartTrainingRequest{
 			TrainingName: trainingName,
@@ -177,7 +177,7 @@ func writeGitignore(trainingRootFs *afero.BasePathFs) error {
 	return nil
 }
 
-func createGoWorkspace(trainingRoot, trainingName string) error {
+func createGoWorkspace(trainingRoot string) error {
 	cmd := exec.Command("go", "work", "init")
 	cmd.Dir = trainingRoot
 

--- a/trainings/jump.go
+++ b/trainings/jump.go
@@ -24,7 +24,7 @@ func (h *Handlers) SelectExercise(ctx context.Context) (string, error) {
 
 	currentExerciseID := h.config.ExerciseConfig(trainingRootFs).ExerciseID
 
-	resp, err := h.newGrpcClient(ctx).GetExercises(ctx, &genproto.GetExercisesRequest{
+	resp, err := h.newGrpcClient().GetExercises(ctx, &genproto.GetExercisesRequest{
 		TrainingName: h.config.TrainingConfig(trainingRootFs).TrainingName,
 		Token:        h.config.GlobalConfig().Token,
 	})
@@ -139,7 +139,7 @@ func (h *Handlers) FindExercise(ctx context.Context, exerciseID string) (string,
 
 	currentExerciseID := h.config.ExerciseConfig(trainingRootFs).ExerciseID
 
-	resp, err := h.newGrpcClient(ctx).GetExercises(ctx, &genproto.GetExercisesRequest{
+	resp, err := h.newGrpcClient().GetExercises(ctx, &genproto.GetExercisesRequest{
 		TrainingName: h.config.TrainingConfig(trainingRootFs).TrainingName,
 		Token:        h.config.GlobalConfig().Token,
 	})
@@ -208,7 +208,7 @@ func (h *Handlers) Jump(ctx context.Context, exerciseID string) error {
 	}
 	trainingRootFs := newTrainingRootFs(trainingRoot)
 
-	resp, err := h.newGrpcClient(ctx).GetExercise(ctx, &genproto.GetExerciseRequest{
+	resp, err := h.newGrpcClient().GetExercise(ctx, &genproto.GetExerciseRequest{
 		TrainingName: h.config.TrainingConfig(trainingRootFs).TrainingName,
 		Token:        h.config.GlobalConfig().Token,
 		ExerciseId:   exerciseID,

--- a/trainings/list.go
+++ b/trainings/list.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *Handlers) List(ctx context.Context) error {
-	trainings, err := h.newGrpcClient(ctx).GetTrainings(context.Background(), &empty.Empty{})
+	trainings, err := h.newGrpcClient().GetTrainings(context.Background(), &empty.Empty{})
 	if err != nil {
 		panic(err)
 	}

--- a/trainings/next.go
+++ b/trainings/next.go
@@ -64,7 +64,7 @@ func (h *Handlers) getNextExercise(
 	currentExerciseID string,
 	trainingRootFs *afero.BasePathFs,
 ) (resp *genproto.NextExerciseResponse, err error) {
-	resp, err = h.newGrpcClient(ctx).NextExercise(
+	resp, err = h.newGrpcClient().NextExercise(
 		ctxWithRequestHeader(ctx, h.cliMetadata),
 		&genproto.NextExerciseRequest{
 			TrainingName:      h.config.TrainingConfig(trainingRootFs).TrainingName,

--- a/trainings/print.go
+++ b/trainings/print.go
@@ -13,11 +13,6 @@ func (h *Handlers) printNotInATrainingDirectory() {
 	fmt.Printf("Please run %s if you didn't start training yet.\n", internal.SprintCommand("tdl training init"))
 }
 
-func (h *Handlers) printExerciseTips() {
-	fmt.Printf("To run solution, please execute " + internal.SprintCommand("tdl training run"))
-	fmt.Println()
-}
-
 func printFinished() {
 	fmt.Println("Congratulations, you finished the training " + color.YellowString("🏆"))
 }


### PR DESCRIPTION
remove deprecated DialContext method because its considered anti-pattern
[grpc docs](https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md#especially-bad-using-deprecated-dialoptions)